### PR TITLE
Add SPI0/1 options for generic RP2040

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -42,3 +42,19 @@ build_flags =
   -DSCK_PIN=2
   -DMOSI_PIN=3
   -DMISO_PIN=0
+
+; ────────── Generic RP2040 board SPI0 (CS 17, SCK 18, MOSI 19, MISO 16) ────
+[env:generic_rp2040_spi0]
+build_flags =
+  -DCS_PIN=17
+  -DSCK_PIN=18
+  -DMOSI_PIN=19
+  -DMISO_PIN=16
+
+; ────────── Generic RP2040 board SPI1 (CS 13, SCK 10, MOSI 11, MISO 12) ────
+[env:generic_rp2040_spi1]
+build_flags =
+  -DCS_PIN=13
+  -DSCK_PIN=10
+  -DMOSI_PIN=11
+  -DMISO_PIN=12

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ This project provides an installation script and firmware for using a RP2040 bas
 
 ## Features
 
-* Supports ADXL345 via RP2040 boards for resonance testing. Supported boards include Fly ADXL345-USB (Mellow), BTT ADXL345, FYSETC Portable Input-Shaper (PIS) and KUSBA v2.
+* Supports ADXL345 via RP2040 boards for resonance testing. Supported boards include Fly ADXL345-USB (Mellow), BTT ADXL345, FYSETC Portable Input-Shaper (PIS), KUSBA v2 and generic RP2040 boards (SPI0 or SPI1).
 * Compatible with OctoPrint’s Pinput Shaping plugin without any code modification.
 * The installation script automatically sets up the required wrapper and configures permissions.
 


### PR DESCRIPTION
## Summary
- add SPI0 and SPI1 envs for generic RP2040 boards
- document SPI0/SPI1 in README

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ed68b9688333bb786fbefb46ad97