### PR TITLE
Add simulator for wrapper testing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,15 @@ This project provides an installation script and firmware for using a RP2040 bas
 
 The firmware running on the RP2040 should be the `adxl345usb` firmware provided in this project. The firmware can be either compiled using VS Code and PlatformIO or downloaded from the GitHub action tab. It outputs CSV-formatted accelerometer data directly over USB (same format as `adxl345spi`).
 
+## Simulator
+
+A simple simulator (`simulator.py`) is included for experimenting with the wrapper without any hardware attached. Run the simulator and point the wrapper to the printed pseudo-serial device:
+
+```bash
+./simulator.py
+./adxl345usb -p /dev/pts/5
+```
+
 ## Troubleshooting
 
 * If you receive a "Permission Denied" error, ensure that the OctoPrint user has execute permissions on the tool:

--- a/simulator.py
+++ b/simulator.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Simulated ADXL345USB device for testing the wrapper.
+
+This script creates a pseudo-serial port that mimics the firmware behaviour.
+It prints the path of the virtual serial device and then waits for commands
+from the wrapper. It responds to ``F=<freq>`` by changing the sample rate and
+streams CSV formatted accelerometer data.
+"""
+
+import argparse
+import os
+import pty
+import random
+import select
+import sys
+import time
+
+
+parser = argparse.ArgumentParser(description="Run a simulated ADXL345USB device")
+parser.add_argument("-f", "--freq", type=int, default=250,
+                    help="initial sample frequency (Hz)")
+args = parser.parse_args()
+
+master_fd, slave_fd = pty.openpty()
+port = os.ttyname(slave_fd)
+print(f"Simulated serial port: {port}")
+sys.stdout.flush()
+
+freq = args.freq
+if freq < 1:
+    freq = 1
+if freq > 3200:
+    freq = 3200
+period = 1.0 / freq
+
+t0 = time.time()
+next_sample = t0 + period
+buffer = b""
+
+
+try:
+    while True:
+        # Check for commands from the wrapper
+        rlist, _, _ = select.select([master_fd], [], [], 0.01)
+        if master_fd in rlist:
+            data = os.read(master_fd, 1024)
+            if not data:
+                break
+            buffer += data
+            while b"\n" in buffer:
+                line, buffer = buffer.split(b"\n", 1)
+                line = line.decode().strip().upper()
+                if line.startswith("F="):
+                    print(f"set frequency to {line[2:]} Hz")
+                    try:
+                        val = int(line[2:])
+                        if 1 <= val <= 3200:
+                            freq = val
+                            period = 1.0 / freq
+                            t0 = time.time()
+                            next_sample = t0 + period
+                            os.write(master_fd, b"time,x,y,z\n")
+                    except ValueError:
+                        pass
+
+        now = time.time()
+        if now >= next_sample:
+            t = now - t0
+            x = random.uniform(-1.0, 1.0)
+            y = random.uniform(-1.0, 1.0)
+            z = random.uniform(-1.0, 1.0)
+            line = f"{t:.6f},{x:.6f},{y:.6f},{z:.6f}\n".encode()
+            os.write(master_fd, line)
+            next_sample += period
+finally:
+    os.close(master_fd)
+    os.close(slave_fd)
+

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,0 +1,32 @@
+import os, pty, subprocess, sys
+WRAPPER = os.path.abspath("adxl345usb")
+
+def run_with_pty(*args):
+    """Run the wrapper attached to a pseudo-terminal."""
+    master, slave = pty.openpty()
+    try:
+        cp = subprocess.run([WRAPPER, *args], stdin=slave,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                            text=True)
+    finally:
+        os.close(master)
+        os.close(slave)
+    return cp.returncode, cp.stdout, cp.stderr
+def test_wrapper_with_simulator():
+    sim = subprocess.Popen([sys.executable, "simulator.py"],
+                           stdout=subprocess.PIPE,
+                           text=True)
+    try:
+        port_line = sim.stdout.readline().strip()
+        assert port_line.startswith("Simulated serial port:"), port_line
+        port = port_line.split(":", 1)[1].strip()
+        code, out, err = run_with_pty("-p", port, "-t", "1")
+        assert code == 0
+        assert "Press Q to stop" in out
+        assert "Captured" in err
+    finally:
+        sim.terminate()
+        try:
+            sim.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            sim.kill()


### PR DESCRIPTION
## Summary
- add `simulator.py` to emulate the ADXL345USB firmware
- document simulator usage in the README
- add pytest covering wrapper interaction with the simulator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843cffce4b88333833f260b34890435