### PR TITLE
Add dual-output mode to simulator

### DIFF
--- a/adxl345usb
+++ b/adxl345usb
@@ -39,6 +39,10 @@ ap.add_argument("-p", "--port", default="/dev/ttyACM1", help="serial device")
 ap.add_argument("-f", "--freq", type=int, default=250, help="sampling rate 1-3200 Hz")
 ap.add_argument("-t", "--time", type=int, default=0,   help="capture seconds (0 = until Q)")
 ap.add_argument("-s", "--save", metavar="FILE", help="CSV output file")
+ap.add_argument("--sensor", type=int, choices=[0,1], default=0,
+                help="when firmware outputs two sensors choose which one to use")
+ap.add_argument("--dual", action="store_true",
+                help="if firmware outputs two sensors save/show both instead of one")
 args = ap.parse_args()
 
 if not (1 <= args.freq <= 3200):
@@ -63,8 +67,6 @@ if args.save:
         csv = open(args.save, "w", buffering=1)
     except OSError as e:
         die(f"cannot open '{args.save}' for writing – {e}", 3)
-    csv.write("time,x,y,z\n")
-    buf_t, buf_x, buf_y, buf_z = [], [], [], []
     FLUSH_EVERY = 1000
 else:
     csv = None
@@ -75,18 +77,49 @@ old_attr  = termios.tcgetattr(fd_stdin)
 tty.setcbreak(fd_stdin)
 
 def flush_buffer():
-    """write buffered rows to file (CSV mode)"""
-    for t, x, y, z in zip(buf_t, buf_x, buf_y, buf_z):
-        csv.write(f"{t:.6f},{x:.6f},{y:.6f},{z:.6f}\n")
-    buf_t.clear(); buf_x.clear(); buf_y.clear(); buf_z.clear()
-    csv.flush()
+    """placeholder; will be replaced after header parsing"""
+    pass
 
 try:
-    # ───── skip the firmware header line ────────────────────────────
+    # ───── determine output format from header ─────────────────────
+    dual_output = False
+    header = ""
     while True:
         hdr = ser.readline()
         if hdr.startswith(b"time,"):
+            header = hdr.decode().strip()
+            if header == "time,x0,y0,z0,x1,y1,z1":
+                dual_output = True
+            elif header != "time,x,y,z":
+                die(f"unexpected header '{header}'", 4)
             break
+
+    if args.dual and not dual_output:
+        sys.stderr.write("WARNING: --dual ignored, firmware outputs a single sensor\n")
+
+    save_dual = dual_output and args.dual
+
+    if csv:
+        if save_dual:
+            csv.write("time,x0,y0,z0,x1,y1,z1\n")
+            buf_t, buf_x0, buf_y0, buf_z0 = [], [], [], []
+            buf_x1, buf_y1, buf_z1 = [], [], []
+            def flush_buffer():
+                for t,x0,y0,z0,x1,y1,z1 in zip(buf_t, buf_x0, buf_y0, buf_z0,
+                                                buf_x1, buf_y1, buf_z1):
+                    csv.write(f"{t:.6f},{x0:.6f},{y0:.6f},{z0:.6f},"
+                              f"{x1:.6f},{y1:.6f},{z1:.6f}\n")
+                buf_t.clear(); buf_x0.clear(); buf_y0.clear(); buf_z0.clear()
+                buf_x1.clear(); buf_y1.clear(); buf_z1.clear()
+                csv.flush()
+        else:
+            csv.write("time,x,y,z\n")
+            buf_t, buf_x, buf_y, buf_z = [], [], [], []
+            def flush_buffer():
+                for t,x,y,z in zip(buf_t, buf_x, buf_y, buf_z):
+                    csv.write(f"{t:.6f},{x:.6f},{y:.6f},{z:.6f}\n")
+                buf_t.clear(); buf_x.clear(); buf_y.clear(); buf_z.clear()
+                csv.flush()
 
     t_start   = time.time()
     t_end     = t_start + args.time if args.time else None
@@ -106,8 +139,16 @@ try:
         if not line:
             continue
         try:
-            t_s, x_s, y_s, z_s = line.decode().strip().split(',')
-            t_f = float(t_s); x_f = float(x_s); y_f = float(y_s); z_f = float(z_s)
+            parts = line.decode().strip().split(',')
+            if dual_output:
+                t_s, x0_s, y0_s, z0_s, x1_s, y1_s, z1_s = parts
+                t_f = float(t_s)
+                vals0 = (float(x0_s), float(y0_s), float(z0_s))
+                vals1 = (float(x1_s), float(y1_s), float(z1_s))
+            else:
+                t_s, x_s, y_s, z_s = parts
+                t_f = float(t_s)
+                vals0 = (float(x_s), float(y_s), float(z_s))
         except ValueError:
             bad_lines += 1
             if bad_lines > 10:
@@ -115,12 +156,30 @@ try:
             continue
 
         if csv:
-            buf_t.append(t_f); buf_x.append(x_f); buf_y.append(y_f); buf_z.append(z_f)
+            if save_dual:
+                buf_t.append(t_f)
+                buf_x0.append(vals0[0]); buf_y0.append(vals0[1]); buf_z0.append(vals0[2])
+                buf_x1.append(vals1[0]); buf_y1.append(vals1[1]); buf_z1.append(vals1[2])
+            else:
+                if dual_output:
+                    chosen = vals0 if args.sensor == 0 else vals1
+                else:
+                    chosen = vals0
+                x_f, y_f, z_f = chosen
+                buf_t.append(t_f); buf_x.append(x_f); buf_y.append(y_f); buf_z.append(z_f)
             if len(buf_t) >= FLUSH_EVERY:
                 flush_buffer()
         else:
-            # human-readable like original C tool
-            print(f"time = {t_f:.3f}, x = {x_f:.3f}, y = {y_f:.3f}, z = {z_f:.3f}")
+            if dual_output and args.dual:
+                print(
+                    f"time = {t_f:.3f}, x0 = {vals0[0]:.3f}, y0 = {vals0[1]:.3f}, z0 = {vals0[2]:.3f}, "
+                    f"x1 = {vals1[0]:.3f}, y1 = {vals1[1]:.3f}, z1 = {vals1[2]:.3f}")
+            else:
+                if dual_output:
+                    chosen = vals0 if args.sensor == 0 else vals1
+                else:
+                    chosen = vals0
+                print(f"time = {t_f:.3f}, x = {chosen[0]:.3f}, y = {chosen[1]:.3f}, z = {chosen[2]:.3f}")
         samples += 1
 
 finally:

--- a/docs/code.md
+++ b/docs/code.md
@@ -15,7 +15,9 @@ It sends a text command `F=<Hz>` to the device to select the sample rate
 without `-s` the wrapper converts each CSV line from the firmware into a human
 friendly message such as `time = 0.100, x = 0.123, y = 0.456, z = 0.789`.
 With `-s` the header `time,x,y,z` and all raw values are written to the chosen
-file while only the banner and a short summary appear on the console.
+file while only the banner and a short summary appear on the console. When the
+firmware outputs data for two sensors the wrapper selects one set of axes using
+the `--sensor` option. To store or display all six axes, pass `--dual`.
 
 Example wrapper output:
 
@@ -27,10 +29,10 @@ time = 0.020, x = -0.611, y = 0.728, z = -0.441
 
 ## Firmware (`src/main.cpp`)
 
-The firmware is written for the Arduino‑mbed RP2040 core. It sets up the ADXL345 over SPI and then streams acceleration samples as `time,x,y,z` lines. A simple text command interface allows changing the sample rate at runtime with `F=<Hz>`.
-Every time the frequency changes the firmware resends the header `time,x,y,z`
+The firmware is written for the Arduino‑mbed RP2040 core. It sets up the ADXL345 over SPI and then streams acceleration samples as `time,x,y,z` lines. A simple text command interface allows changing the sample rate at runtime with `F=<Hz>`. When compiled with `DUAL_SPI` the output header becomes `time,x0,y0,z0,x1,y1,z1`.
+Every time the frequency changes the firmware resends the appropriate header
 followed by the data rows. Each row starts with the elapsed time in seconds and
-then lists the X, Y and Z axes in units of `g`.
+then lists the accelerometer axes in units of `g`.
 
 Example device output:
 
@@ -42,7 +44,7 @@ time,x,y,z
 
 ## Simulator (`simulator.py`)
 
-For development without hardware, a simulator is provided. It creates a pseudo‑terminal that mimics the firmware's behaviour so the wrapper and plugin can be tested locally. The tests use this simulator to validate the wrapper.
+For development without hardware, a simulator is provided. It creates a pseudo‑terminal that mimics the firmware's behaviour so the wrapper and plugin can be tested locally. Add `--dual` when running it to emit the dual‑sensor format. The tests use this simulator to validate the wrapper.
 
 ## Tests
 

--- a/docs/spi-ports.md
+++ b/docs/spi-ports.md
@@ -10,5 +10,6 @@ The firmware supports multiple boards. Each board uses specific GPIOs for the AD
 | KUSBA v2 | 1 | 2 | 3 | 0 |
 | Generic RP2040 board (SPI0) | 17 | 18 | 19 | 16 |
 | Generic RP2040 board (SPI1) | 13 | 10 | 11 | 12 |
+| Generic RP2040 board (dual) | 17/13 | 18/10 | 19/11 | 16/12 |
 
 Refer to the comments in `platformio.ini` for a description of each environment. Custom boards can override the `CS_PIN`, `SCK_PIN`, `MOSI_PIN` and `MISO_PIN` macros via `build_flags`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,21 +8,27 @@ Run the wrapper directly to stream human‑readable output:
 ./adxl345usb -p /dev/ttyACM0
 ```
 
-Use `-s FILE` to record CSV data and `-t SEC` to stop after a given time.
+Use `-s FILE` to record CSV data and `-t SEC` to stop after a given time. When
+the firmware outputs two sensors (`time,x0,y0,z0,x1,y1,z1` header) the `--sensor`
+option selects which set of axes to write (0 or 1, default 0). Add `--dual` to
+store all six axes in the file (header `time,x0,y0,z0,x1,y1,z1`).
 
 On startup the wrapper prints `Press Q to stop`. If `-s` is provided the
-resulting file begins with the header `time,x,y,z` and contains raw numeric
-rows. Without `-s` each line on the console is formatted like
-`time = 0.100, x = 0.123, y = 0.456, z = 0.789`. When saving to a file the
-banner and a short summary remain on the console.
+resulting file begins with `time,x,y,z` unless `--dual` is used, in which case
+the full dual header is written. Without `-s` each line on the console is
+formatted like `time = 0.100, x = 0.123, y = 0.456, z = 0.789`. Use `--dual` to
+show both sensors in this human readable mode. When saving to a file the banner
+and a short summary remain on the console.
 
 ## Using the simulator
 
 The repository ships with a simulator for development without hardware. Start it
-and point the wrapper to the shown pseudo‑terminal:
+and point the wrapper to the shown pseudo‑terminal. Pass `--dual` to the
+simulator to mimic firmware built with `DUAL_SPI`:
 
 ```bash
-./simulator.py
+./simulator.py        # single output
+./simulator.py --dual # dual output
 ./adxl345usb -p /dev/pts/5 -t 1
 ```
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -58,3 +58,16 @@ build_flags =
   -DSCK_PIN=10
   -DMOSI_PIN=11
   -DMISO_PIN=12
+
+; ────────── Generic RP2040 board dual SPI0/SPI1 ────
+[env:generic_rp2040_dual]
+build_flags =
+  -DDUAL_SPI
+  -DCS0_PIN=17
+  -DSCK0_PIN=18
+  -DMOSI0_PIN=19
+  -DMISO0_PIN=16
+  -DCS1_PIN=13
+  -DSCK1_PIN=10
+  -DMOSI1_PIN=11
+  -DMISO1_PIN=12

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ See the [docs](docs/) directory for detailed guides on setup, usage, development
 
 ## Firmware Configuration
 
-The firmware running on the RP2040 should be the `adxl345usb` firmware provided in this project. The firmware can be either compiled using VS Code and PlatformIO or downloaded from the GitHub action tab. It outputs CSV-formatted accelerometer data directly over USB (same format as `adxl345spi`).
+The firmware running on the RP2040 should be the `adxl345usb` firmware provided in this project. The firmware can be either compiled using VS Code and PlatformIO or downloaded from the GitHub action tab. It outputs CSV-formatted accelerometer data directly over USB (same format as `adxl345spi`). When compiled with `DUAL_SPI` it streams `time,x0,y0,z0,x1,y1,z1` lines which the wrapper can save using the `--dual` option.
 
 ## Simulator
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 // * Builds with the *standard* Arduino‑MBed core.
 // * Streams ADXL345 data exactly like navaismo/adxl345spi – header
 //   "time,x,y,z" followed by CSV lines, default 250 Hz.
+// * Optional dual‑sensor mode outputs "time,x0,y0,z0,x1,y1,z1".
 // * Uses an mbed::SPI instance.
 //
 // =============================================================
@@ -20,7 +21,7 @@
 
 /* ───── Board-specific pins (overridable via build_flags) ─────────── */
 #ifndef CS_PIN
-#  define CS_PIN 9          // legacy default
+#  define CS_PIN 9          // legacy default (single sensor)
 #endif
 #ifndef SCK_PIN
 #  define SCK_PIN 10
@@ -32,11 +33,50 @@
 #  define MISO_PIN 12
 #endif
 
-/* ───── SPI instance on the chosen GPIOs ──────────────────────────── */
+#ifdef DUAL_SPI
+#  ifndef CS0_PIN
+#    define CS0_PIN 17
+#  endif
+#  ifndef SCK0_PIN
+#    define SCK0_PIN 18
+#  endif
+#  ifndef MOSI0_PIN
+#    define MOSI0_PIN 19
+#  endif
+#  ifndef MISO0_PIN
+#    define MISO0_PIN 16
+#  endif
+
+#  ifndef CS1_PIN
+#    define CS1_PIN 13
+#  endif
+#  ifndef SCK1_PIN
+#    define SCK1_PIN 10
+#  endif
+#  ifndef MOSI1_PIN
+#    define MOSI1_PIN 11
+#  endif
+#  ifndef MISO1_PIN
+#    define MISO1_PIN 12
+#  endif
+#endif
+
+/* SPI instance(s) on the chosen GPIOs */
+#ifdef DUAL_SPI
+static mbed::SPI spi0(
+    digitalPinToPinName(MOSI0_PIN),
+    digitalPinToPinName(MISO0_PIN),
+    digitalPinToPinName(SCK0_PIN));
+static mbed::SPI spi1(
+    digitalPinToPinName(MOSI1_PIN),
+    digitalPinToPinName(MISO1_PIN),
+    digitalPinToPinName(SCK1_PIN));
+#else
 static mbed::SPI spiPort(
     digitalPinToPinName(MOSI_PIN),
     digitalPinToPinName(MISO_PIN),
     digitalPinToPinName(SCK_PIN));
+#endif
 
 constexpr uint32_t SPI_SPEED = 2'000'000;   // 2 MHz
 
@@ -46,9 +86,31 @@ constexpr float ACC_CONV = 16.0f / 4096.0f;
 volatile uint32_t sample_us = 4'000;        // 250 Hz default
 
 /* ---------------- Low‑level helpers ------------------ */
+#ifdef DUAL_SPI
+inline void cs0Low()  { digitalWrite(CS0_PIN, LOW);  }
+inline void cs0High() { digitalWrite(CS0_PIN, HIGH); }
+inline void cs1Low()  { digitalWrite(CS1_PIN, LOW);  }
+inline void cs1High() { digitalWrite(CS1_PIN, HIGH); }
+#else
 inline void csLow()  { digitalWrite(CS_PIN, LOW);  }
 inline void csHigh() { digitalWrite(CS_PIN, HIGH); }
+#endif
 
+#ifdef DUAL_SPI
+void adxlWrite(mbed::SPI &port, int cs_pin, uint8_t reg, uint8_t val) {
+    digitalWrite(cs_pin, LOW);
+    port.write(reg);
+    port.write(val);
+    digitalWrite(cs_pin, HIGH);
+}
+
+void adxlReadBurst(mbed::SPI &port, int cs_pin, uint8_t startReg, uint8_t *buf, size_t len) {
+    digitalWrite(cs_pin, LOW);
+    port.write(0x80 | 0x40 | startReg);   // READ | MULTI
+    for (size_t i = 0; i < len; ++i) buf[i] = port.write(0);
+    digitalWrite(cs_pin, HIGH);
+}
+#else
 void adxlWrite(uint8_t reg, uint8_t val) {
     csLow();
     spiPort.write(reg);
@@ -62,8 +124,22 @@ void adxlReadBurst(uint8_t startReg, uint8_t *buf, size_t len) {
     for (size_t i = 0; i < len; ++i) buf[i] = spiPort.write(0);
     csHigh();
 }
+#endif
 
 /* ---------------- Sensor initialisation -------------- */
+#ifdef DUAL_SPI
+void setupADXL(mbed::SPI &port, int cs_pin, uint8_t bw_rate_code = 0x0A) {
+    pinMode(cs_pin, OUTPUT);
+    digitalWrite(cs_pin, HIGH);
+
+    port.frequency(SPI_SPEED);
+    port.format(8 /*bits*/, 3 /*mode*/);  // SPI mode 3
+
+    adxlWrite(port, cs_pin, REG_DATA_FORMAT, 0x0B); // full-res ±16g
+    adxlWrite(port, cs_pin, REG_BW_RATE, bw_rate_code);
+    adxlWrite(port, cs_pin, REG_POWER_CTL, 0x08);   // measurement mode
+}
+#else
 void setupADXL(uint8_t bw_rate_code = 0x0A) { // 0x0A = 100 Hz placeholder
     pinMode(CS_PIN, OUTPUT);
     csHigh();
@@ -75,6 +151,7 @@ void setupADXL(uint8_t bw_rate_code = 0x0A) { // 0x0A = 100 Hz placeholder
     adxlWrite(REG_BW_RATE, bw_rate_code);
     adxlWrite(REG_POWER_CTL, 0x08);     // measurement mode
 }
+#endif
 
 /* ---------------- USB command parser ----------------- */
 String cmd;
@@ -88,7 +165,11 @@ void handleCommand() {
         if (f >= 1 && f <= 3200) {
             sample_us = 1'000'000UL / f;
             t0_us = micros();                  // start time at 0 again
+#ifdef DUAL_SPI
+            Serial.println("time,x0,y0,z0,x1,y1,z1");
+#else
             Serial.println("time,x,y,z");     // header for new block
+#endif
         }
     } else if (cmd.startsWith("H")) {
         Serial.println("Commands: F=<1-3200> Hz  | H help");
@@ -101,9 +182,16 @@ void setup() {
     Serial.begin(2'000'000);
     while (!Serial) { }
 
+#ifdef DUAL_SPI
+    setupADXL(spi0, CS0_PIN);
+    setupADXL(spi1, CS1_PIN);
+    t0_us = micros();
+    Serial.println("time,x0,y0,z0,x1,y1,z1");
+#else
     setupADXL();
     t0_us = micros();
     Serial.println("time,x,y,z");
+#endif
 }
 
 /* ---------------- Main loop -------------------------- */
@@ -121,6 +209,34 @@ void loop() {
     if ((int32_t)(now - next_us) >= 0) {
         next_us += sample_us;
 
+#ifdef DUAL_SPI
+        uint8_t raw0[6], raw1[6];
+        adxlReadBurst(spi0, CS0_PIN, REG_DATAX0, raw0, 6);
+        adxlReadBurst(spi1, CS1_PIN, REG_DATAX0, raw1, 6);
+
+        int16_t rx0 = (raw0[1] << 8) | raw0[0];
+        int16_t ry0 = (raw0[3] << 8) | raw0[2];
+        int16_t rz0 = (raw0[5] << 8) | raw0[4];
+        int16_t rx1 = (raw1[1] << 8) | raw1[0];
+        int16_t ry1 = (raw1[3] << 8) | raw1[2];
+        int16_t rz1 = (raw1[5] << 8) | raw1[4];
+
+        float x0 = rx0 * ACC_CONV;
+        float y0 = ry0 * ACC_CONV;
+        float z0 = rz0 * ACC_CONV;
+        float x1 = rx1 * ACC_CONV;
+        float y1 = ry1 * ACC_CONV;
+        float z1 = rz1 * ACC_CONV;
+        float t = (now - t0_us) * 1e-6f;
+
+        Serial.print(t, 6);  Serial.print(',');
+        Serial.print(x0, 6); Serial.print(',');
+        Serial.print(y0, 6); Serial.print(',');
+        Serial.print(z0, 6); Serial.print(',');
+        Serial.print(x1, 6); Serial.print(',');
+        Serial.print(y1, 6); Serial.print(',');
+        Serial.println(z1, 6);
+#else
         uint8_t raw[6];
         adxlReadBurst(REG_DATAX0, raw, 6);
         int16_t rx = (raw[1] << 8) | raw[0];
@@ -136,5 +252,6 @@ void loop() {
         Serial.print(x, 6);  Serial.print(',');
         Serial.print(y, 6);  Serial.print(',');
         Serial.println(z, 6);
+#endif
     }
 }

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -30,3 +30,23 @@ def test_wrapper_with_simulator():
             sim.wait(timeout=5)
         except subprocess.TimeoutExpired:
             sim.kill()
+
+
+def test_wrapper_with_simulator_dual():
+    sim = subprocess.Popen([sys.executable, "simulator.py", "--dual"],
+                           stdout=subprocess.PIPE,
+                           text=True)
+    try:
+        port_line = sim.stdout.readline().strip()
+        assert port_line.startswith("Simulated serial port:"), port_line
+        port = port_line.split(":", 1)[1].strip()
+        code, out, err = run_with_pty("--dual", "-p", port, "-t", "1")
+        assert code == 0
+        assert "x0" in out
+        assert "Captured" in err
+    finally:
+        sim.terminate()
+        try:
+            sim.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            sim.kill()


### PR DESCRIPTION
## Summary
- add `--dual` option to simulator for two-sensor output
- show how to use simulator `--dual` in usage docs
- mention dual mode in code overview
- test wrapper against simulator dual mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68443804869c8333a83c003ebe21922c