### PR TITLE
Add GoogleTest dual SPI test

### DIFF
--- a/.github/workflows/test-firmware.yml
+++ b/.github/workflows/test-firmware.yml
@@ -1,0 +1,23 @@
+name: CI – firmware unit tests
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pyserial pytest platformio
+    - name: Run PlatformIO tests
+      run: pio test -e native -e native_dual

--- a/docs/code.md
+++ b/docs/code.md
@@ -49,3 +49,5 @@ For development without hardware, a simulator is provided. It creates a pseudoâ€
 ## Tests
 
 The `tests` directory contains a minimal Pytest suite exercising both the wrapper and the simulator. Running `pytest` ensures that the wrapper behaves correctly even when PySerial is missing and that it can talk to the simulator.
+
+Firmware sources are also tested using GoogleTest via PlatformIO. The `native` and `native_dual` environments build the firmware for the host, enabling single- and dual-sensor tests respectively. Run `pio test -e native -e native_dual` to execute them.

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,11 +8,21 @@ flash it directly when your board is connected.
 
 ## Running the tests
 
-Install the dependencies and run `pytest`:
+Install the dependencies and run the Python tests with `pytest`:
 
 ```bash
 pip install pyserial pytest
 pytest -q
 ```
 
-The test suite exercises the wrapper and the simulator.
+The Python test suite exercises the wrapper and the simulator.
+
+### Firmware unit tests
+
+The firmware can be tested on the host using PlatformIO and GoogleTest. Install
+PlatformIO alongside the Python dependencies and run:
+
+```bash
+pip install platformio
+pio test -e native -e native_dual
+```

--- a/platformio.ini
+++ b/platformio.ini
@@ -4,15 +4,34 @@ default_envs = fly_adxl345_usb      ; keep the old default
 
 [env]
 platform          = raspberrypi
-board             = pico
 framework         = arduino
 upload_protocol   = picotool
 monitor_speed     = 2000000
 platform_packages =
   platformio/toolchain-gccarmnoneeabi@~1.90301.0
 
+; ────────── Native host environment for unit tests ───────────
+[env:native]
+platform          = native
+framework         =
+test_framework    = googletest
+build_flags       = -Itest/stubs -std=gnu++17
+build_src_filter =
+  +<src/main.cpp>
+test_filter       = test_single
+
+[env:native_dual]
+platform          = native
+framework         =
+test_framework    = googletest
+build_flags       = -Itest/stubs -DDUAL_SPI -std=gnu++17
+build_src_filter =
+  +<src/main.cpp>
+test_filter       = test_dual
+
 ; ────────── Fly-ADXL345-USB  (CS 9, SCK 10, MOSI 11, MISO 12) ───────
 [env:fly_adxl345_usb]
+board = pico
 build_flags =
   -DCS_PIN=9
   -DSCK_PIN=10
@@ -21,6 +40,7 @@ build_flags =
 
 ; ────────── Fysetc Portable Input-Shaper  (CS 13, SCK 10, MOSI 11, MISO 12) ───
 [env:fysetc_pis]
+board = pico
 build_flags =
   -DCS_PIN=13
   -DSCK_PIN=10
@@ -29,6 +49,7 @@ build_flags =
 
 ; ────────── BTT ADXL345  (CS 9, SCK 10, MOSI 11, MISO 8) ────────
 [env:btt_adxl345]
+board = pico
 build_flags =
   -DCS_PIN=9
   -DSCK_PIN=10
@@ -37,6 +58,7 @@ build_flags =
 
   ; ────────── KUSBA v2  (CS 1, SCK 2, MOSI 3, MISO 0) ────────
 [env:kusba_v2]
+board = pico
 build_flags =
   -DCS_PIN=1
   -DSCK_PIN=2
@@ -45,6 +67,7 @@ build_flags =
 
 ; ────────── Generic RP2040 board SPI0 (CS 17, SCK 18, MOSI 19, MISO 16) ────
 [env:generic_rp2040_spi0]
+board = pico
 build_flags =
   -DCS_PIN=17
   -DSCK_PIN=18
@@ -53,6 +76,7 @@ build_flags =
 
 ; ────────── Generic RP2040 board SPI1 (CS 13, SCK 10, MOSI 11, MISO 12) ────
 [env:generic_rp2040_spi1]
+board = pico
 build_flags =
   -DCS_PIN=13
   -DSCK_PIN=10
@@ -61,6 +85,7 @@ build_flags =
 
 ; ────────── Generic RP2040 board dual SPI0/SPI1 ────
 [env:generic_rp2040_dual]
+board = pico
 build_flags =
   -DDUAL_SPI
   -DCS0_PIN=17

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,18 @@ A simple simulator (`simulator.py`) is included for experimenting with the wrapp
 
 ```bash
 ./simulator.py
-./adxl345usb -p /dev/pts/5
+  ./adxl345usb -p /dev/pts/5
+```
+
+## Testing
+
+Python tests verify the wrapper and simulator, while PlatformIO builds run
+GoogleTest-based firmware tests. Install the dependencies and run:
+
+```bash
+pip install pyserial pytest platformio
+pytest -q
+pio test -e native -e native_dual
 ```
 
 ## Troubleshooting

--- a/test/stubs/Arduino.h
+++ b/test/stubs/Arduino.h
@@ -1,0 +1,66 @@
+#ifndef ARDUINO_H
+#define ARDUINO_H
+#include <string>
+#include <cstdint>
+#include <vector>
+#include <cstdio>
+#include <cctype>
+
+#define OUTPUT 1
+#define INPUT 0
+#define HIGH 1
+#define LOW 0
+
+class String {
+public:
+    std::string s;
+    String() {}
+    String(const char* str) : s(str) {}
+    void trim() {
+        const char* ws = " \t\r\n";
+        size_t b = s.find_first_not_of(ws);
+        if (b == std::string::npos) { s.clear(); return; }
+        size_t e = s.find_last_not_of(ws);
+        s = s.substr(b, e - b + 1);
+    }
+    void toUpperCase() {
+        for (char &c : s) c = toupper(static_cast<unsigned char>(c));
+    }
+    bool startsWith(const char* prefix) const {
+        return s.rfind(prefix, 0) == 0;
+    }
+    String substring(size_t from) const {
+        return String(s.substr(from).c_str());
+    }
+    long toInt() const {
+        return std::stol(s);
+    }
+    String& operator+=(char c) { s += c; return *this; }
+    String& operator=(const char* str) { s = str; return *this; }
+};
+
+struct SerialStub {
+    std::string out;
+    std::vector<char> in;
+    void begin(unsigned long) {}
+    operator bool() const { return true; }
+    bool available() const { return !in.empty(); }
+    char read() { char c = in.front(); in.erase(in.begin()); return c; }
+    void print(const char* str) { out += str; }
+    void print(char c) { out += c; }
+    void print(float v, int digits) { char buf[32]; std::snprintf(buf, sizeof(buf), "%.*f", digits, v); out += buf; }
+    void print(const String& s) { out += s.s; }
+    void println(const char* str) { out += str; out += '\n'; }
+    void println(float v, int digits) { char buf[32]; std::snprintf(buf, sizeof(buf), "%.*f", digits, v); out += buf; out += '\n'; }
+    void println(const String& s) { out += s.s; out += '\n'; }
+};
+inline SerialStub Serial;
+
+inline int digitalPinToPinName(int pin) { return pin; }
+inline void pinMode(int, int) {}
+inline void digitalWrite(int, int) {}
+
+inline uint32_t fakeMicros = 0;
+inline uint32_t micros() { return fakeMicros; }
+
+#endif

--- a/test/stubs/SPI.h
+++ b/test/stubs/SPI.h
@@ -1,0 +1,4 @@
+#ifndef SPI_H
+#define SPI_H
+class SPISettings {};
+#endif

--- a/test/stubs/mbed.h
+++ b/test/stubs/mbed.h
@@ -1,0 +1,17 @@
+#ifndef MBED_H
+#define MBED_H
+#include <cstdint>
+#include <vector>
+
+namespace mbed {
+class SPI {
+public:
+    std::vector<uint8_t> written;
+    SPI(int, int, int) {}
+    void frequency(int) {}
+    void format(int, int) {}
+    uint8_t write(uint8_t val) { written.push_back(val); return 0; }
+};
+}
+
+#endif

--- a/test/test_dual/test_main.cpp
+++ b/test/test_dual/test_main.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+#include "Arduino.h"
+#include "mbed.h"
+
+// firmware code compiled with DUAL_SPI via build flags
+#include "../../src/main.cpp"
+
+class HandleCommandTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        Serial.out.clear();
+        cmd = "";
+        sample_us = 4000; // default
+    }
+};
+
+TEST(DualSpi, SetupPrintsHeader) {
+    Serial.out.clear();
+    fakeMicros = 0;
+    setup();
+    EXPECT_EQ(Serial.out, std::string("time,x0,y0,z0,x1,y1,z1\n"));
+}
+
+TEST_F(HandleCommandTest, SetFrequencyValid) {
+    cmd = "F=500";
+    fakeMicros = 100; // arbitrary
+    handleCommand();
+    EXPECT_EQ(sample_us, 2000u);
+    EXPECT_EQ(Serial.out, std::string("time,x0,y0,z0,x1,y1,z1\n"));
+}
+
+TEST_F(HandleCommandTest, SetFrequencyInvalid) {
+    cmd = "F=0";
+    fakeMicros = 50;
+    handleCommand();
+    EXPECT_EQ(sample_us, 4000u);
+    EXPECT_EQ(Serial.out, std::string(""));
+}
+
+TEST_F(HandleCommandTest, HelpCommand) {
+    cmd = "H";
+    handleCommand();
+    EXPECT_EQ(Serial.out, std::string("Commands: F=<1-3200> Hz  | H help\n"));
+}
+
+int main(int argc, char **argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/test_single/test_main.cpp
+++ b/test/test_single/test_main.cpp
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+#include "Arduino.h"
+#include "mbed.h"
+
+#include "../../src/main.cpp"
+
+class HandleCommandTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        Serial.out.clear();
+        cmd = "";
+        sample_us = 4000; // default
+    }
+};
+
+TEST(SingleSpi, SetupPrintsHeader) {
+    Serial.out.clear();
+    fakeMicros = 0;
+    setup();
+    EXPECT_EQ(Serial.out, std::string("time,x,y,z\n"));
+}
+
+TEST_F(HandleCommandTest, SetFrequencyValid) {
+    cmd = "F=500";
+    fakeMicros = 100;
+    handleCommand();
+    EXPECT_EQ(sample_us, 2000u);
+    EXPECT_EQ(Serial.out, std::string("time,x,y,z\n"));
+}
+
+TEST_F(HandleCommandTest, SetFrequencyInvalid) {
+    cmd = "F=0";
+    fakeMicros = 50;
+    handleCommand();
+    EXPECT_EQ(sample_us, 4000u);
+    EXPECT_EQ(Serial.out, std::string(""));
+}
+
+TEST_F(HandleCommandTest, HelpCommand) {
+    cmd = "H";
+    handleCommand();
+    EXPECT_EQ(Serial.out, std::string("Commands: F=<1-3200> Hz  | H help\n"));
+}
+
+int main(int argc, char **argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- compile unit tests with `DUAL_SPI` enabled
- verify setup header and frequency command in dual sensor mode
- run PlatformIO unit tests automatically in GitHub Actions
- document firmware tests and clarify how to run them on the host

## Testing
- `pytest -q`
- `pio test -e native -e native_dual`


------
https://chatgpt.com/codex/tasks/task_e_68453fe32ed08333874033566772cf0f